### PR TITLE
only company profiles can create property

### DIFF
--- a/frontend/src/components/dashboard/DashBoard.js
+++ b/frontend/src/components/dashboard/DashBoard.js
@@ -10,6 +10,7 @@ import axiosInstance from '../../api/axios.js';
 
 
 const DashBoard = () => {
+    //state to hold the role of the signed in user
     const [role, setRole] = useState(null)
     let navigate = useNavigate();
 
@@ -17,6 +18,7 @@ const DashBoard = () => {
         navigate('/create-property');
     }
 
+    // make a call to get the role of the user based on the stored id in the local storage
     useEffect(() => {
         let role = ''
         const id = localStorage.getItem("ID");
@@ -36,6 +38,7 @@ const DashBoard = () => {
                     <UserInfo />
                     <Financial />
                     <SubmittedRequests />
+                    {/* the button to create a property is only accessible to company profiles */}
                     {
                         role === "COMPANY" &&
                         <div>

--- a/frontend/src/components/dashboard/DashBoard.js
+++ b/frontend/src/components/dashboard/DashBoard.js
@@ -1,19 +1,34 @@
 import React from 'react'
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import PropertyContainer from '../property/PropertyContainer.js'
 import UserInfo from './UserInfo.js';
 import { Container, Col, Row, Button } from "react-bootstrap";
 import Financial from './Financial.js';
 import SubmittedRequests from './SubmittedRequests.js';
 import { useNavigate } from 'react-router-dom';
+import axiosInstance from '../../api/axios.js';
 
 
 const DashBoard = () => {
+    const [role, setRole] = useState(null)
     let navigate = useNavigate();
 
     function handleGoToProperty() {
         navigate('/create-property');
     }
+
+    useEffect(() => {
+        let role = ''
+        const id = localStorage.getItem("ID");
+        axiosInstance
+            .get(`profiles/user/${id}/`)
+            .then((response) => {
+                role = response.data.role;
+                setRole(role);
+                console.log(role);
+            }, []);
+    })
+
     return (
         <Container className="mt-5">
             <Row>
@@ -21,7 +36,14 @@ const DashBoard = () => {
                     <UserInfo />
                     <Financial />
                     <SubmittedRequests />
-                    <Button variant="primary" style={{width: "150px", marginLeft: "120px"}} onClick={handleGoToProperty}>Add Property</Button>
+                    {
+                        role === "COMPANY" &&
+                        <div>
+                            <Button variant="primary" style={{ width: "150px", marginLeft: "120px" }} onClick={handleGoToProperty}>Add Property</Button>
+                            <Button variant="primary" style={{ width: "150px", marginLeft: "120px" }} onClick={handleGoToProperty}>Send Key</Button>
+                        </div>
+
+                    }
                 </Col>
                 <Col>
                     <PropertyContainer />

--- a/frontend/src/components/property/PropertyPage.js
+++ b/frontend/src/components/property/PropertyPage.js
@@ -11,11 +11,12 @@ const PropertyPage = () => {
   let navigate = useNavigate();
 
   const { propertyId } = useParams();
-  const { property, fetchPropertyById } = useProperty();
+  const { property, fetchPropertyById } = useProperty(); //receive needed functions from the property context
 
   useEffect(() => {
     if (propertyId) {
       //this is useful only for company accounts
+      // make the api call from the backend
       fetchPropertyById(propertyId);
     }
   }, []);

--- a/frontend/src/components/property/PropertyPage.js
+++ b/frontend/src/components/property/PropertyPage.js
@@ -11,44 +11,12 @@ const PropertyPage = () => {
   let navigate = useNavigate();
 
   const { propertyId } = useParams();
-  const { property, setProperty, fetchProperty } = useProperty();
+  const { property, fetchPropertyById } = useProperty();
 
-  function findPropertyById(propertiesObj, propertyId) {
-    // Convert the properties object into an array of its values
-    const propertiesArray = Object.values(propertiesObj);
-    console.log(propertiesObj)
-    console.log(propertiesArray)
-    const matchingProperty = propertiesArray.find(property => property.id === parseInt(propertyId, 10));
-    console.log(matchingProperty)
-    return matchingProperty;
-  }
-
-  // get information on active user
   useEffect(() => {
     if (propertyId) {
-      axiosInstance
-        .get(`/properties/property-profile/${propertyId}/`)
-        .then((response) => {
-          console.log("the response from the get property with id :" + response);
-          setProperty({
-            id: response.data.id,
-            company: response.data.company,
-            num_condo_units: response.data.num_condo_units,
-            num_parking_units: response.data.num_parking_units,
-            num_storage_units: response.data.num_storage_units,
-            address: response.data.address,
-            city: response.data.city,
-            province: response.data.province,
-            postal_code: response.data.postal_code,
-            condo_units: response.data.condo_units,
-            parking_units: response.data.parking_units,
-            storage_units: response.data.storage_units,
-          });
-          console.log(response.data);
-        })
-        .catch((error) => {
-          console.error("Error fetching user profile:", error.message);
-        });
+      //this is useful only for company accounts
+      fetchPropertyById(propertyId);
     }
   }, []);
 

--- a/frontend/src/utils/hooks/PropertyContext.js
+++ b/frontend/src/utils/hooks/PropertyContext.js
@@ -11,58 +11,7 @@ export const useProperty = () => useContext(PropertyContext);
 
 export const PropertyProvider = ({ children }) => {
 
-    //TODO hard coded until the api is confirmed with db content as well
-    const [properties, setProperties] = useState({
-        // property1: {
-        //     id: "1",
-        //     company: "",
-        //     name: "Estate Alpha",
-        //     location: "Greenwich, London",
-        //     image: propertyPhoto,
-        //     units: [
-        //         { id: 1, name: "The Buckingham Suite", address: '123 Main St', location: 'Downtown', price: 1200000, size: 1000 },
-        //         { id: 1, name: "The Buckingham Suite", address: '123 Main St', location: 'Downtown', price: 1200000, size: 1000 },
-        //     ],
-        //     parkingSpots: [
-        //         { id: 1, level: 2, size: 200, price: 50000, slotNumber: 12 },
-        //     ],
-        //     lockers: [
-        //         { id: 1, location: 'Basement', size: 50, number: 3, price: 10000 },
-        //     ],
-        // },
-        // property2: {
-        //     id: "2",
-        //     company: "",
-        //     name: "Villa Beta",
-        //     location: "Beverly Hills, California",
-        //     image: propertyPhoto1,
-        //     units: [
-        //         { id: 1, name: "Sunset Manor", address: '456 Grand Ave', location: 'Hills', price: 2500000, size: 1500 },
-        //     ],
-        //     parkingSpots: [
-        //         { id: 1, level: 1, size: 250, price: 75000, slotNumber: 8 },
-        //     ],
-        //     lockers: [
-        //         { id: 1, location: 'Sub-basement', size: 60, number: 5, price: 20000 },
-        //     ],
-        // },
-        // property3: {
-        //     id: "3",
-        //     company: "",
-        //     name: "Condo Gamma",
-        //     location: "Manhattan, New York",
-        //     image: propertyPhoto2,
-        //     units: [
-        //         { id: 1, name: "The Empire Loft", address: '789 Broadway St', location: 'Midtown', price: 900000, size: 800 },
-        //     ],
-        //     parkingSpots: [
-        //         { id: 1, level: 3, size: 180, price: 60000, slotNumber: 20 },
-        //     ],
-        //     lockers: [
-        //         { id: 1, location: 'Lower Level', size: 40, number: 7, price: 15000 },
-        //     ],
-        // }
-    });
+    const [properties, setProperties] = useState({});
     const [property, setProperty] = useState({
         id: -1,
         company: -1,
@@ -94,7 +43,8 @@ export const PropertyProvider = ({ children }) => {
             });
     };
 
-    const fetchProperty = async (id) => {
+    //to be used when seeing propperties on the compnay dashboard
+    const fetchPropertyById = async (id) => {
         axiosInstance
 
             .get(`/properties/property-profile/${id}`)
@@ -134,7 +84,7 @@ export const PropertyProvider = ({ children }) => {
     };
 
     return (
-        <PropertyContext.Provider value={{ properties, fetchAllProperties, addProperty, updateProperty, deleteProperty, property, setProperty, fetchProperty }}>
+        <PropertyContext.Provider value={{ properties, fetchAllProperties, addProperty, updateProperty, deleteProperty, property, setProperty, fetchPropertyById }}>
             {children}
         </PropertyContext.Provider>
     );


### PR DESCRIPTION
Small PR concerning what can be seen from the dashboard based on the user type (PUBLIC or COMPANY)

before: public users were able to create properties because they had access to the "add property" button 

after:
- implement dashboard view based on the type of user (public or company)
- the option to create the property only shows for "COMPANY" roles now
Relates: #4 