### PR TITLE
Update registration endpoints to use PATCH method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://drive.google.com/drive/folders/1PvXIhUKsRwX6eLFUD0lRPzZBL13F3WjT?usp=sha
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/bb3c9af8236b4e89bc59c9172e2e41a3)](https://app.codacy.com/gh/JRB958/THE-390/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
-Date: Sat Mar 23 20:46:08 UTC 2024
+Date: Tue Apr  2 02:12:57 UTC 2024
 
 Code Quality Indicators
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ https://drive.google.com/drive/folders/1PvXIhUKsRwX6eLFUD0lRPzZBL13F3WjT?usp=sha
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/bb3c9af8236b4e89bc59c9172e2e41a3)](https://app.codacy.com/gh/JRB958/THE-390/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
-
-Date: Tue Apr  2 02:12:57 UTC 2024
-
+Date: Tue Apr  9 17:56:09 UTC 2024
 
 Code Quality Indicators
 

--- a/backend/user_profile/urls.py
+++ b/backend/user_profile/urls.py
@@ -22,9 +22,9 @@ urlpatterns = [
     path('public-profile/<int:user_id>/parking-units/', PublicProfileViewSet.as_view({'get':'get_parking_units'})),
     path('public-profile/<int:user_id>/storage-units/', PublicProfileViewSet.as_view({'get':'get_storage_units'})),
     # register unit to public profile with registration key 
-    path('public-profile/register-condo/', PublicProfileViewSet.as_view({'get': 'register_condo'})),
-    path('public-profile/register-storage/', PublicProfileViewSet.as_view({'get': 'register_storage'})),
-    path('public-profile/register-parking/', PublicProfileViewSet.as_view({'get': 'register_parking'})),
+    path('public-profile/register-condo/', PublicProfileViewSet.as_view({'patch': 'register_condo'})),
+    path('public-profile/register-storage/', PublicProfileViewSet.as_view({'patch': 'register_storage'})),
+    path('public-profile/register-parking/', PublicProfileViewSet.as_view({'patch': 'register_parking'})),
     # finance 
     path('company-profile/<int:company_id>/finance-report/', CompanyFinanceView.as_view())
 ]

--- a/frontend/src/components/registrationKey/SubmitRegistrationButton.js
+++ b/frontend/src/components/registrationKey/SubmitRegistrationButton.js
@@ -13,7 +13,7 @@ function SubmitRegistrationButton() {
 
     const sendKey = async () => {
         try {
-            const response = await axiosInstance.get('profiles/public-profile/register-condo/', {
+            const response = await axiosInstance.patch('profiles/public-profile/register-condo/', {
                 key: regKey,
                 user: parseInt(localStorage.getItem('ID')),
             });


### PR DESCRIPTION
Fixed issue with registering a condo unit to public profile by updating the request method used. 
previously, this was done using a GET request, and i updated it to a PATCH request, since using this endpoint will update information concerning the public profile and the condo unit involved. 

even though it they are not used yet, i made the same change for registering a parking and storage unit to a user with the register key. 

Specific changes: 
- update method to PATCH in public profile urls, for endpoint using the concerned view methods 
- updated React.js api to use patch rather than get

Related Issue: #175 